### PR TITLE
Canvas drawText bug fix

### DIFF
--- a/stripedprocessbutton/src/main/java/com/github/nikartm/stripedprocessbutton/AnimatedStripedDrawable.java
+++ b/stripedprocessbutton/src/main/java/com/github/nikartm/stripedprocessbutton/AnimatedStripedDrawable.java
@@ -117,11 +117,6 @@ public class AnimatedStripedDrawable extends ShapeElement implements Element.OnC
             paintStripes.setAlpha(mDrawable.getStripeAlpha());
             paintStripes.setShader(stripesShader, Paint.ShaderType.LINEAR_SHADER);
             canvas.drawRoundRect(rectF, cornerRadius, cornerRadius, paintStripes);
-            canvas.drawText(textPaint, isRunning() ? mDrawable.getLoadingText() : mDrawable.getButtonText(),
-                    mViewWidth / 2f, (mViewHeight + textPaint.getTextSize()) / 2f);
-        } else {
-            canvas.drawText(textPaint, mDrawable.getButtonText(),
-                    mViewWidth / 2f, (mViewHeight + textPaint.getTextSize()) / 2f);
         }
     }
 

--- a/stripedprocessbutton/src/main/java/com/github/nikartm/stripedprocessbutton/StripedProcessButton.java
+++ b/stripedprocessbutton/src/main/java/com/github/nikartm/stripedprocessbutton/StripedProcessButton.java
@@ -45,7 +45,7 @@ public class StripedProcessButton extends Button implements Component.BindStateC
         mAnimatedDrawable = new AnimatedStripedDrawable(mStripedDrawable);
         mAnimatedDrawable.setComponent(this);
         setBindStateChangedListener(this);
-        addDrawTask(this:: onDraw);
+        addDrawTask(this:: onDraw, BETWEEN_BACKGROUND_AND_CONTENT);
     }
 
     /**


### PR DESCRIPTION
Fix for the issue : the button text was being drawn using canvas.drawText as the button text was getting hidden beneath the shader
